### PR TITLE
Add run_galaxy.sh

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -89,7 +89,7 @@ RUN julia -e 'using IJulia; IJulia.installkernel("Julia-DIVAnd precompiled, 4 CP
 
 
 USER root
-ADD run.sh /usr/local/bin/run.sh
+ADD run_galaxy.sh /usr/local/bin/run_galaxy.sh
 USER jovyan
 
 ## use 33 (www-data) as nextcloud
@@ -108,4 +108,4 @@ USER jovyan
 COPY ./healthcheck_notebook.sh /bin/healthcheck.sh
 HEALTHCHECK --interval=30s --timeout=10s CMD /bin/healthcheck.sh
 
-CMD ["bash", "/usr/local/bin/run.sh"]
+CMD ["bash", "/usr/local/bin/run_galaxy.sh"]

--- a/run_galaxy.sh
+++ b/run_galaxy.sh
@@ -35,7 +35,7 @@ if test -n "$NB_UID"; then
 fi
 
 
-jupyter trust /work/DIVAnd-Workshop/notebooks/*/*.ipynb
+jupyter trust /home/$NB_USER/work/DIVAnd-Workshop/notebooks/*/*.ipynb
 
 jupyter lab --no-browser
 

--- a/run_galaxy.sh
+++ b/run_galaxy.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+
+# The IPython image starts as privileged user.
+# The parent Galaxy server is mounting data into /import with the same 
+# permissions as the Galaxy server is running on.
+# In case of 1450 as UID and GID we are fine, because our preconfigured ipython
+# user owns this UID/GID. 
+# (1450 is the user id the Galaxy-Docker Image is using)
+# If /import is not owned by 1450 we need to create a new user with the same
+# UID/GID as /import and make everything accessible to this new user.
+#
+# In the end the IPython Server is started as non-privileged user. Either
+# with the UID 1450 (preconfigured jupyter user) or a newly created 'galaxy' user
+# with the same UID/GID as /import.
+
+export PATH=/home/$NB_USER/.local/bin:$PATH
+
+if [ ! -d /home/$NB_USER/work/DIVAnd-Workshop/Adriatic/WOD/CTD ]; then
+    mkdir -p /home/$NB_USER/work/DIVAnd-Workshop/Adriatic/WOD
+    ln -s /data/Diva-Workshops-data/WOD/* /home/$NB_USER/work/DIVAnd-Workshop/Adriatic/WOD/
+    chown $NB_USER /work/DIVAnd-Workshop/Adriatic/WOD
+fi
+
+echo "Copy notebooks"
+if [ ! -d /home/$NB_USER/work/DIVAnd-Workshop ]; then
+    cp -R /data/Diva-Workshops-master/notebooks /home/$NB_USER/work/DIVAnd-Workshop
+    chown $NB_USER /work/DIVAnd-Workshop/notebooks/*/*.ipynb
+fi
+
+# this is very slow and should not be necessary in most cases
+if test -n "$NB_UID"; then
+    echo "Change ownership to user id $NB_UID"
+    chown -R "$NB_UID":"$NB_GID" /home/jovyan/.local
+    chown -R "$NB_UID":"$NB_GID" /home/jovyan/.julia
+fi
+
+
+jupyter trust /work/DIVAnd-Workshop/notebooks/*/*.ipynb
+
+jupyter lab --no-browser
+


### PR DESCRIPTION
This file can come as a replacement of run.sh. The issue with run.sh is that some permissions are in comments because you say it's too slow. So I tried to do another version of the run.sh (run_galaxy.sh) that way maybe in the dockerfile you can add a variable ARG where we can decide which file to use either run.sh or run_galaxy.sh. And so, on the docker hub we will have 2 tags one with the run.sh version and one for the galaxy. What do you think of that ? 
For the run_galaxy.sh I took inspiration of this file https://github.com/anuprulez/ml-jupyter-notebook/blob/master/startup.sh.