### PR TITLE
Update Julia version and disable pre-compilation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+Diva-Workshops-main/
+master.zip


### PR DESCRIPTION
- Julia now installed using `juliaup`
- No Python and PyPlot installation (not needed in the notebooks)
- Update list of packages to be installed
- Creation of `data`, `figures` and `output` directories